### PR TITLE
adds decimal to page count

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -257,7 +257,7 @@ export default class NovelWordCountPlugin extends Plugin {
 					: getPluralizedCount("word", counts.wordCount);
 			case CountType.Page:
 				return abbreviateDescriptions
-					? `${Math.ceil(counts.pageCount).toLocaleString()}p`
+					? `${(counts.pageCount).toFixed(1)}p`
 					: getPluralizedCount("page", counts.pageCount);
 			case CountType.Note:
 				return abbreviateDescriptions


### PR DESCRIPTION
Hi there, I'd like to revisit my pull request from last year (https://github.com/isaaclyman/novel-word-count-obsidian/pull/3).

Since you have added word counts separately, I think, the problem you mentioned last time that you'd like there to be a comma to separate the 1,000 thousander digits seems to no longer be an issue.

My change to `toFixed(1)`  adds a single decimal to the page count. Unlike Microsoft Word and the like, where you can see how much of the next page you've filled up with your text, so that the whole number of pages is enough, in Obsidian I find it useful to have a single decimal so you can see how much text you actually have.

No worries if this still isn't to your liking, just thought I'd bring it up again :)
Thanks!