### PR TITLE
Add explicit include directories setting

### DIFF
--- a/logic/file.ts
+++ b/logic/file.ts
@@ -1,4 +1,4 @@
-import type NovelWordCountPlugin from 'main';
+import type NovelWordCountPlugin from "main";
 import {
 	App,
 	CachedMetadata,
@@ -8,14 +8,14 @@ import {
 	Vault,
 	getAllTags,
 	parseFrontMatterAliases,
-} from 'obsidian';
-import { DebugHelper } from './debug';
+} from "obsidian";
+import { DebugHelper } from "./debug";
 import {
 	NovelWordCountSettings,
 	PageCountType,
 	WordCountType,
-} from './settings';
-import { CancellationToken } from './cancellation';
+} from "./settings";
+import { CancellationToken } from "./cancellation";
 
 export interface CountData {
 	isCountable: boolean;
@@ -59,12 +59,12 @@ export class FileHelper {
 	public async getAllFileCounts(
 		cancellationToken: CancellationToken
 	): Promise<CountsByFile> {
-		const debugEnd = this.debugHelper.debugStart('getAllFileCounts');
+		const debugEnd = this.debugHelper.debugStart("getAllFileCounts");
 		let files: TFile[] = [];
 		if (
 			this.plugin.settings.showAdvanced &&
-			this.plugin.settings.includeDirectories !== '*' &&
-			this.plugin.settings.includeDirectories !== ''
+			this.plugin.settings.includeDirectories !== "*" &&
+			this.plugin.settings.includeDirectories !== ""
 		) {
 			const includePath = this.vault.getAbstractFileByPath(
 				this.plugin.settings.includeDirectories
@@ -187,7 +187,7 @@ export class FileHelper {
 	}
 
 	private countNonWhitespaceCharacters(content: string): number {
-		return (content.replace(/\s+/g, '') || []).length;
+		return (content.replace(/\s+/g, "") || []).length;
 	}
 
 	private cjkRegex =
@@ -225,7 +225,7 @@ export class FileHelper {
 
 	private getChildPaths(counts: CountsByFile, path: string): string[] {
 		const childPaths = Object.keys(counts).filter(
-			(countPath) => path === '/' || countPath.startsWith(path + '/')
+			(countPath) => path === "/" || countPath.startsWith(path + "/")
 		);
 		return childPaths;
 	}
@@ -321,7 +321,7 @@ export class FileHelper {
 
 	private getWordGoal(metadata?: CachedMetadata): number | null {
 		const goal =
-			metadata && metadata.frontmatter && metadata.frontmatter['word-goal'];
+			metadata && metadata.frontmatter && metadata.frontmatter["word-goal"];
 		if (!goal || isNaN(Number(goal))) {
 			return null;
 		}
@@ -348,11 +348,11 @@ export class FileHelper {
 
 		if (this.settings.excludeComments) {
 			const hasComments =
-				meaningfulContent.includes('%%') || meaningfulContent.includes('<!--');
+				meaningfulContent.includes("%%") || meaningfulContent.includes("<!--");
 			if (hasComments) {
 				meaningfulContent = meaningfulContent.replace(
 					/(?:%%[\s\S]+?%%|<!--[\s\S]+?-->)/gim,
-					''
+					""
 				);
 			}
 		}
@@ -361,26 +361,26 @@ export class FileHelper {
 	}
 
 	private readonly FileTypeAllowlist = new Set([
-		'',
+		"",
 		// Markdown extensions
-		'markdown',
-		'md',
-		'mdml',
-		'mdown',
-		'mdtext',
-		'mdtxt',
-		'mdwn',
-		'mkd',
-		'mkdn',
+		"markdown",
+		"md",
+		"mdml",
+		"mdown",
+		"mdtext",
+		"mdtxt",
+		"mdwn",
+		"mkd",
+		"mkdn",
 		// Text files
-		'txt',
-		'text',
-		'rtf',
+		"txt",
+		"text",
+		"rtf",
 		// MD with embedded code
-		'qmd',
-		'rmd',
+		"qmd",
+		"rmd",
 		// MD for screenwriters
-		'fountain',
+		"fountain",
 	]);
 
 	private shouldCountFile(file: TFile, metadata?: CachedMetadata): boolean {
@@ -394,10 +394,10 @@ export class FileHelper {
 
 		if (
 			metadata.frontmatter &&
-			metadata.frontmatter.hasOwnProperty('wordcount') &&
+			metadata.frontmatter.hasOwnProperty("wordcount") &&
 			(metadata.frontmatter.wordcount === null ||
 				metadata.frontmatter.wordcount === false ||
-				metadata.frontmatter.wordcount === 'false')
+				metadata.frontmatter.wordcount === "false")
 		) {
 			return false;
 		}
@@ -405,11 +405,11 @@ export class FileHelper {
 		const tags = getAllTags(metadata).map((tag) => tag.toLowerCase());
 		if (
 			tags.length &&
-			(tags.includes('#excalidraw') ||
+			(tags.includes("#excalidraw") ||
 				tags
-					.filter((tag) => tag.startsWith('#exclude'))
-					.map((tag) => tag.replace(/[-_]/g, ''))
-					.includes('#excludefromwordcount'))
+					.filter((tag) => tag.startsWith("#exclude"))
+					.map((tag) => tag.replace(/[-_]/g, ""))
+					.includes("#excludefromwordcount"))
 		) {
 			return false;
 		}

--- a/logic/file.ts
+++ b/logic/file.ts
@@ -1,4 +1,4 @@
-import type NovelWordCountPlugin from "main";
+import type NovelWordCountPlugin from 'main';
 import {
 	App,
 	CachedMetadata,
@@ -8,14 +8,14 @@ import {
 	Vault,
 	getAllTags,
 	parseFrontMatterAliases,
-} from "obsidian";
-import { DebugHelper } from "./debug";
+} from 'obsidian';
+import { DebugHelper } from './debug';
 import {
 	NovelWordCountSettings,
 	PageCountType,
 	WordCountType,
-} from "./settings";
-import { CancellationToken } from "./cancellation";
+} from './settings';
+import { CancellationToken } from './cancellation';
 
 export interface CountData {
 	isCountable: boolean;
@@ -59,9 +59,26 @@ export class FileHelper {
 	public async getAllFileCounts(
 		cancellationToken: CancellationToken
 	): Promise<CountsByFile> {
-		const debugEnd = this.debugHelper.debugStart("getAllFileCounts");
-
-		const files = this.vault.getFiles();
+		const debugEnd = this.debugHelper.debugStart('getAllFileCounts');
+		let files: TFile[] = [];
+		if (
+			this.plugin.settings.showAdvanced &&
+			this.plugin.settings.includeDirectories !== '*' &&
+			this.plugin.settings.includeDirectories !== ''
+		) {
+			const includePath = this.vault.getAbstractFileByPath(
+				this.plugin.settings.includeDirectories
+			);
+			if (includePath instanceof TFolder) {
+				files = includePath.children.filter(
+					(abstractFile): abstractFile is TFile => abstractFile instanceof TFile
+				);
+			} else {
+				// May want to raise an error here?
+			}
+		} else {
+			files = this.vault.getFiles();
+		}
 		const counts: CountsByFile = {};
 
 		for (const file of files) {
@@ -170,7 +187,7 @@ export class FileHelper {
 	}
 
 	private countNonWhitespaceCharacters(content: string): number {
-		return (content.replace(/\s+/g, "") || []).length;
+		return (content.replace(/\s+/g, '') || []).length;
 	}
 
 	private cjkRegex =
@@ -208,7 +225,7 @@ export class FileHelper {
 
 	private getChildPaths(counts: CountsByFile, path: string): string[] {
 		const childPaths = Object.keys(counts).filter(
-			(countPath) => path === "/" || countPath.startsWith(path + "/")
+			(countPath) => path === '/' || countPath.startsWith(path + '/')
 		);
 		return childPaths;
 	}
@@ -304,7 +321,7 @@ export class FileHelper {
 
 	private getWordGoal(metadata?: CachedMetadata): number | null {
 		const goal =
-			metadata && metadata.frontmatter && metadata.frontmatter["word-goal"];
+			metadata && metadata.frontmatter && metadata.frontmatter['word-goal'];
 		if (!goal || isNaN(Number(goal))) {
 			return null;
 		}
@@ -331,11 +348,11 @@ export class FileHelper {
 
 		if (this.settings.excludeComments) {
 			const hasComments =
-				meaningfulContent.includes("%%") || meaningfulContent.includes("<!--");
+				meaningfulContent.includes('%%') || meaningfulContent.includes('<!--');
 			if (hasComments) {
 				meaningfulContent = meaningfulContent.replace(
 					/(?:%%[\s\S]+?%%|<!--[\s\S]+?-->)/gim,
-					""
+					''
 				);
 			}
 		}
@@ -344,26 +361,26 @@ export class FileHelper {
 	}
 
 	private readonly FileTypeAllowlist = new Set([
-		"",
+		'',
 		// Markdown extensions
-		"markdown",
-		"md",
-		"mdml",
-		"mdown",
-		"mdtext",
-		"mdtxt",
-		"mdwn",
-		"mkd",
-		"mkdn",
+		'markdown',
+		'md',
+		'mdml',
+		'mdown',
+		'mdtext',
+		'mdtxt',
+		'mdwn',
+		'mkd',
+		'mkdn',
 		// Text files
-		"txt",
-		"text",
-		"rtf",
+		'txt',
+		'text',
+		'rtf',
 		// MD with embedded code
-		"qmd",
-		"rmd",
+		'qmd',
+		'rmd',
 		// MD for screenwriters
-		"fountain",
+		'fountain',
 	]);
 
 	private shouldCountFile(file: TFile, metadata?: CachedMetadata): boolean {
@@ -377,10 +394,10 @@ export class FileHelper {
 
 		if (
 			metadata.frontmatter &&
-			metadata.frontmatter.hasOwnProperty("wordcount") &&
+			metadata.frontmatter.hasOwnProperty('wordcount') &&
 			(metadata.frontmatter.wordcount === null ||
 				metadata.frontmatter.wordcount === false ||
-				metadata.frontmatter.wordcount === "false")
+				metadata.frontmatter.wordcount === 'false')
 		) {
 			return false;
 		}
@@ -388,11 +405,11 @@ export class FileHelper {
 		const tags = getAllTags(metadata).map((tag) => tag.toLowerCase());
 		if (
 			tags.length &&
-			(tags.includes("#excalidraw") ||
+			(tags.includes('#excalidraw') ||
 				tags
-					.filter((tag) => tag.startsWith("#exclude"))
-					.map((tag) => tag.replace(/[-_]/g, ""))
-					.includes("#excludefromwordcount"))
+					.filter((tag) => tag.startsWith('#exclude'))
+					.map((tag) => tag.replace(/[-_]/g, ''))
+					.includes('#excludefromwordcount'))
 		) {
 			return false;
 		}

--- a/logic/settings.ts
+++ b/logic/settings.ts
@@ -1,66 +1,66 @@
-import type NovelWordCountPlugin from 'main';
+import type NovelWordCountPlugin from "main";
 import {
 	App,
 	PluginSettingTab,
 	Setting,
 	TextComponent,
 	debounce,
-} from 'obsidian';
+} from "obsidian";
 
 export enum CountType {
-	None = 'none',
-	Word = 'word',
-	Page = 'page',
-	PageDecimal = 'pagedecimal',
-	ReadTime = 'readtime',
-	PercentGoal = 'percentgoal',
-	Note = 'note',
-	Character = 'character',
-	Link = 'link',
-	Embed = 'embed',
-	Alias = 'alias',
-	Created = 'created',
-	Modified = 'modified',
-	FileSize = 'filesize',
+	None = "none",
+	Word = "word",
+	Page = "page",
+	PageDecimal = "pagedecimal",
+	ReadTime = "readtime",
+	PercentGoal = "percentgoal",
+	Note = "note",
+	Character = "character",
+	Link = "link",
+	Embed = "embed",
+	Alias = "alias",
+	Created = "created",
+	Modified = "modified",
+	FileSize = "filesize",
 }
 
 export const COUNT_TYPE_DISPLAY_STRINGS: { [countType: string]: string } = {
-	[CountType.None]: 'None',
-	[CountType.Word]: 'Word Count',
-	[CountType.Page]: 'Page Count',
-	[CountType.PageDecimal]: 'Page Count (decimal)',
-	[CountType.ReadTime]: 'Reading Time',
-	[CountType.PercentGoal]: '% of Word Goal',
-	[CountType.Note]: 'Note Count',
-	[CountType.Character]: 'Character Count',
-	[CountType.Link]: 'Link Count',
-	[CountType.Embed]: 'Embed Count',
-	[CountType.Alias]: 'First Alias',
-	[CountType.Created]: 'Created Date',
-	[CountType.Modified]: 'Last Updated Date',
-	[CountType.FileSize]: 'File Size',
+	[CountType.None]: "None",
+	[CountType.Word]: "Word Count",
+	[CountType.Page]: "Page Count",
+	[CountType.PageDecimal]: "Page Count (decimal)",
+	[CountType.ReadTime]: "Reading Time",
+	[CountType.PercentGoal]: "% of Word Goal",
+	[CountType.Note]: "Note Count",
+	[CountType.Character]: "Character Count",
+	[CountType.Link]: "Link Count",
+	[CountType.Embed]: "Embed Count",
+	[CountType.Alias]: "First Alias",
+	[CountType.Created]: "Created Date",
+	[CountType.Modified]: "Last Updated Date",
+	[CountType.FileSize]: "File Size",
 };
 
 export const COUNT_TYPE_DESCRIPTIONS: { [countType: string]: string } = {
-	[CountType.None]: 'Hidden.',
-	[CountType.Word]: 'Total words.',
-	[CountType.Page]: 'Total pages, rounded up.',
+	[CountType.None]: "Hidden.",
+	[CountType.Word]: "Total words.",
+	[CountType.Page]: "Total pages, rounded up.",
 	[CountType.PageDecimal]:
-		'Total pages, precise to 2 digits after the decimal.',
-	[CountType.ReadTime]: 'Estimated time to read the note.',
+		"Total pages, precise to 2 digits after the decimal.",
+	[CountType.ReadTime]: "Estimated time to read the note.",
 	[CountType.PercentGoal]:
 		"Set a word goal by adding the 'word-goal' property to a note.",
-	[CountType.Note]: 'Total notes.',
+	[CountType.Note]: "Total notes.",
 	[CountType.Character]:
-		'Total characters (letters, symbols, numbers, and spaces).',
-	[CountType.Link]: 'Total links to other notes.',
-	[CountType.Embed]: 'Total embedded images, files, and notes.',
-	[CountType.Alias]: 'The first alias property of each note.',
+		"Total characters (letters, symbols, numbers, and spaces).",
+	[CountType.Link]: "Total links to other notes.",
+	[CountType.Embed]: "Total embedded images, files, and notes.",
+	[CountType.Alias]: "The first alias property of each note.",
 	[CountType.Created]:
-		'Creation date. (On folders: earliest creation date of any note.)',
+		"Creation date. (On folders: earliest creation date of any note.)",
 	[CountType.Modified]:
-		'Date of last edit. (On folders: latest edit date of any note.)',
-	[CountType.FileSize]: 'Total size on hard drive.',
+		"Date of last edit. (On folders: latest edit date of any note.)",
+	[CountType.FileSize]: "Total size on hard drive.",
 };
 
 export const UNFORMATTABLE_COUNT_TYPES = [
@@ -72,16 +72,16 @@ export const UNFORMATTABLE_COUNT_TYPES = [
 export const COUNT_TYPE_DEFAULT_SHORT_SUFFIXES: {
 	[countType: string]: string;
 } = {
-	[CountType.Word]: 'w',
-	[CountType.Page]: 'p',
-	[CountType.PageDecimal]: 'p',
-	[CountType.PercentGoal]: '%',
-	[CountType.Note]: 'n',
-	[CountType.Character]: 'ch',
-	[CountType.Link]: 'x',
-	[CountType.Embed]: 'em',
-	[CountType.Created]: '/c',
-	[CountType.Modified]: '/u',
+	[CountType.Word]: "w",
+	[CountType.Page]: "p",
+	[CountType.PageDecimal]: "p",
+	[CountType.PercentGoal]: "%",
+	[CountType.Note]: "n",
+	[CountType.Character]: "ch",
+	[CountType.Link]: "x",
+	[CountType.Embed]: "em",
+	[CountType.Created]: "/c",
+	[CountType.Modified]: "/u",
 };
 
 export function getDescription(countType: CountType): string {
@@ -106,9 +106,9 @@ export const COUNT_TYPES = [
 ];
 
 export enum AlignmentType {
-	Inline = 'inline',
-	Right = 'right',
-	Below = 'below',
+	Inline = "inline",
+	Right = "right",
+	Below = "below",
 }
 
 export const ALIGNMENT_TYPES = [
@@ -118,19 +118,19 @@ export const ALIGNMENT_TYPES = [
 ];
 
 export enum CharacterCountType {
-	StringLength = 'AllCharacters',
-	ExcludeWhitespace = 'ExcludeWhitespace',
+	StringLength = "AllCharacters",
+	ExcludeWhitespace = "ExcludeWhitespace",
 }
 
 export enum WordCountType {
-	SpaceDelimited = 'SpaceDelimited',
-	CJK = 'CJK',
-	AutoDetect = 'AutoDetect',
+	SpaceDelimited = "SpaceDelimited",
+	CJK = "CJK",
+	AutoDetect = "AutoDetect",
 }
 
 export enum PageCountType {
-	ByWords = 'ByWords',
-	ByChars = 'ByChars',
+	ByWords = "ByWords",
+	ByChars = "ByChars",
 }
 
 export interface NovelWordCountSettings {
@@ -177,23 +177,23 @@ export const DEFAULT_SETTINGS: NovelWordCountSettings = {
 	useAdvancedFormatting: false,
 	// NOTES
 	countType: CountType.Word,
-	countTypeSuffix: 'w',
+	countTypeSuffix: "w",
 	countType2: CountType.None,
-	countType2Suffix: '',
+	countType2Suffix: "",
 	countType3: CountType.None,
-	countType3Suffix: '',
-	pipeSeparator: '|',
+	countType3Suffix: "",
+	pipeSeparator: "|",
 	abbreviateDescriptions: false,
 	alignment: AlignmentType.Inline,
 	// FOLDERS
 	showSameCountsOnFolders: true,
 	folderCountType: CountType.Word,
-	folderCountTypeSuffix: 'w',
+	folderCountTypeSuffix: "w",
 	folderCountType2: CountType.None,
-	folderCountType2Suffix: '',
+	folderCountType2Suffix: "",
 	folderCountType3: CountType.None,
-	folderCountType3Suffix: '',
-	folderPipeSeparator: '|',
+	folderCountType3Suffix: "",
+	folderPipeSeparator: "|",
 	folderAbbreviateDescriptions: false,
 	folderAlignment: AlignmentType.Inline,
 	// ADVANCED
@@ -206,7 +206,7 @@ export const DEFAULT_SETTINGS: NovelWordCountSettings = {
 	characterCountType: CharacterCountType.StringLength,
 	wordCountType: WordCountType.SpaceDelimited,
 	pageCountType: PageCountType.ByWords,
-	includeDirectories: '',
+	includeDirectories: "",
 	excludeComments: false,
 	debugMode: false,
 };
@@ -235,21 +235,21 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	//
 
 	private renderNoteSettings(containerEl: HTMLElement): void {
-		const mainHeader = containerEl.createEl('div', {
+		const mainHeader = containerEl.createEl("div", {
 			cls: [
-				'setting-item',
-				'setting-item-heading',
-				'novel-word-count-settings-header',
+				"setting-item",
+				"setting-item-heading",
+				"novel-word-count-settings-header",
 			],
 		});
-		mainHeader.createEl('div', { text: 'Notes' });
-		mainHeader.createEl('div', {
-			text: 'You can display up to three data types side by side.',
-			cls: 'setting-item-description',
+		mainHeader.createEl("div", { text: "Notes" });
+		mainHeader.createEl("div", {
+			text: "You can display up to three data types side by side.",
+			cls: "setting-item-description",
 		});
 
 		new Setting(containerEl)
-			.setDesc('Use advanced formatting')
+			.setDesc("Use advanced formatting")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.useAdvancedFormatting)
@@ -264,7 +264,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - DATA TYPE 1
 
 		this.renderCountTypeSetting(containerEl, {
-			name: '1st data type to show',
+			name: "1st data type to show",
 			oldCountType: this.plugin.settings.countType,
 			setNewCountType: (value) => {
 				this.plugin.settings.countType = value;
@@ -282,7 +282,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - DATA TYPE 2
 
 		this.renderCountTypeSetting(containerEl, {
-			name: '2nd data type to show',
+			name: "2nd data type to show",
 			oldCountType: this.plugin.settings.countType2,
 			setNewCountType: (value) => {
 				this.plugin.settings.countType2 = value;
@@ -300,7 +300,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - DATA TYPE 3
 
 		this.renderCountTypeSetting(containerEl, {
-			name: '3rd data type to show',
+			name: "3rd data type to show",
 			oldCountType: this.plugin.settings.countType3,
 			setNewCountType: (value) => {
 				this.plugin.settings.countType3 = value;
@@ -317,7 +317,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 		// NOTE - SEPARATOR
 		if (this.plugin.settings.useAdvancedFormatting) {
-			new Setting(containerEl).setName('Data type separator').addText((text) =>
+			new Setting(containerEl).setName("Data type separator").addText((text) =>
 				text
 					.setValue(this.plugin.settings.pipeSeparator)
 					.onChange(async (value) => {
@@ -332,7 +332,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 		if (!this.plugin.settings.useAdvancedFormatting) {
 			new Setting(containerEl)
-				.setName('Abbreviate descriptions')
+				.setName("Abbreviate descriptions")
 				.setDesc("E.g. show '120w' instead of '120 words'")
 				.addToggle((toggle) =>
 					toggle
@@ -348,15 +348,15 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - ALIGNMENT
 
 		new Setting(containerEl)
-			.setName('Alignment')
+			.setName("Alignment")
 			.setDesc(
-				'Show data inline with file/folder names, right-aligned, or underneath'
+				"Show data inline with file/folder names, right-aligned, or underneath"
 			)
 			.addDropdown((drop) => {
 				drop
-					.addOption(AlignmentType.Inline, 'Inline')
-					.addOption(AlignmentType.Right, 'Right-aligned')
-					.addOption(AlignmentType.Below, 'Below')
+					.addOption(AlignmentType.Inline, "Inline")
+					.addOption(AlignmentType.Right, "Right-aligned")
+					.addOption(AlignmentType.Below, "Below")
 					.setValue(this.plugin.settings.alignment)
 					.onChange(async (value: AlignmentType) => {
 						this.plugin.settings.alignment = value;
@@ -367,13 +367,13 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	}
 
 	private renderFolderSettings(containerEl: HTMLElement): void {
-		containerEl.createEl('hr');
+		containerEl.createEl("hr");
 
 		// SHOW SAME DATA ON FOLDERS
 
 		new Setting(containerEl)
 			.setHeading()
-			.setName('Folders: Same data as Notes')
+			.setName("Folders: Same data as Notes")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.showSameCountsOnFolders)
@@ -390,7 +390,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - DATA TYPE 1
 
 			this.renderCountTypeSetting(containerEl, {
-				name: '1st data type to show',
+				name: "1st data type to show",
 				oldCountType: this.plugin.settings.folderCountType,
 				setNewCountType: (value) => {
 					this.plugin.settings.folderCountType = value;
@@ -411,7 +411,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - DATA TYPE 2
 
 			this.renderCountTypeSetting(containerEl, {
-				name: '2nd data type to show',
+				name: "2nd data type to show",
 				oldCountType: this.plugin.settings.folderCountType2,
 				setNewCountType: (value) => {
 					this.plugin.settings.folderCountType2 = value;
@@ -432,7 +432,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - DATA TYPE 3
 
 			this.renderCountTypeSetting(containerEl, {
-				name: '3rd data type to show',
+				name: "3rd data type to show",
 				oldCountType: this.plugin.settings.folderCountType3,
 				setNewCountType: (value) => {
 					this.plugin.settings.folderCountType3 = value;
@@ -453,7 +453,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - SEPARATOR
 			if (this.plugin.settings.useAdvancedFormatting) {
 				new Setting(containerEl)
-					.setName('Data type separator')
+					.setName("Data type separator")
 					.addText((text) =>
 						text
 							.setValue(this.plugin.settings.folderPipeSeparator)
@@ -469,7 +469,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 			if (!this.plugin.settings.useAdvancedFormatting) {
 				new Setting(containerEl)
-					.setName('Abbreviate descriptions')
+					.setName("Abbreviate descriptions")
 					.addToggle((toggle) =>
 						toggle
 							.setValue(this.plugin.settings.folderAbbreviateDescriptions)
@@ -483,11 +483,11 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 			// FOLDER - ALIGNMENT
 
-			new Setting(containerEl).setName('Alignment').addDropdown((drop) => {
+			new Setting(containerEl).setName("Alignment").addDropdown((drop) => {
 				drop
-					.addOption(AlignmentType.Inline, 'Inline')
-					.addOption(AlignmentType.Right, 'Right-aligned')
-					.addOption(AlignmentType.Below, 'Below')
+					.addOption(AlignmentType.Inline, "Inline")
+					.addOption(AlignmentType.Right, "Right-aligned")
+					.addOption(AlignmentType.Below, "Below")
 					.setValue(this.plugin.settings.folderAlignment)
 					.onChange(async (value: AlignmentType) => {
 						this.plugin.settings.folderAlignment = value;
@@ -499,12 +499,12 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	}
 
 	private renderAdvancedSettings(containerEl: HTMLElement): void {
-		containerEl.createEl('hr');
+		containerEl.createEl("hr");
 
 		new Setting(containerEl)
 			.setHeading()
-			.setName('Show advanced options')
-			.setDesc('Language compatibility and fine-tuning')
+			.setName("Show advanced options")
+			.setDesc("Language compatibility and fine-tuning")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.showAdvanced)
@@ -519,13 +519,13 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// INCLUDE DIRECTORIES
 
 			new Setting(containerEl)
-				.setName('Include directories')
+				.setName("Include directories")
 				.setDesc(
-					'Only include specific directories. Defaults to all directories. Can be used to exclude directories from displaying counts.'
+					"Only include specific directories. Defaults to all directories. Can be used to exclude directories from displaying counts."
 				)
 				.addText((txt) => {
 					txt
-						.setPlaceholder('')
+						.setPlaceholder("")
 						.setValue(this.plugin.settings.includeDirectories.toString())
 						.onChange(async (value) => {
 							this.plugin.settings.includeDirectories = value;
@@ -537,9 +537,9 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// EXCLUDE COMMENTS
 
 			new Setting(containerEl)
-				.setName('Exclude comments')
+				.setName("Exclude comments")
 				.setDesc(
-					'Exclude %%Obsidian%% and <!--HTML--> comments from counts. May affect performance on large vaults.'
+					"Exclude %%Obsidian%% and <!--HTML--> comments from counts. May affect performance on large vaults."
 				)
 				.addToggle((toggle) =>
 					toggle
@@ -554,14 +554,14 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// CHARACTER COUNT METHOD
 
 			new Setting(containerEl)
-				.setName('Character count method')
-				.setDesc('For language compatibility')
+				.setName("Character count method")
+				.setDesc("For language compatibility")
 				.addDropdown((drop) => {
 					drop
-						.addOption(CharacterCountType.StringLength, 'All characters')
+						.addOption(CharacterCountType.StringLength, "All characters")
 						.addOption(
 							CharacterCountType.ExcludeWhitespace,
-							'Exclude whitespace'
+							"Exclude whitespace"
 						)
 						.setValue(this.plugin.settings.characterCountType)
 						.onChange(async (value: CharacterCountType) => {
@@ -574,16 +574,16 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// WORD COUNT METHOD
 
 			new Setting(containerEl)
-				.setName('Word count method')
-				.setDesc('For language compatibility')
+				.setName("Word count method")
+				.setDesc("For language compatibility")
 				.addDropdown((drop) => {
 					drop
 						.addOption(
 							WordCountType.SpaceDelimited,
-							'Space-delimited (European languages)'
+							"Space-delimited (European languages)"
 						)
-						.addOption(WordCountType.CJK, 'Han/Kana/Hangul (CJK)')
-						.addOption(WordCountType.AutoDetect, 'Auto-detect by file')
+						.addOption(WordCountType.CJK, "Han/Kana/Hangul (CJK)")
+						.addOption(WordCountType.AutoDetect, "Auto-detect by file")
 						.setValue(this.plugin.settings.wordCountType)
 						.onChange(async (value: WordCountType) => {
 							this.plugin.settings.wordCountType = value;
@@ -597,12 +597,12 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// PAGE COUNT METHOD
 
 			new Setting(containerEl)
-				.setName('Page count method')
-				.setDesc('For language compatibility')
+				.setName("Page count method")
+				.setDesc("For language compatibility")
 				.addDropdown((drop) => {
 					drop
-						.addOption(PageCountType.ByWords, 'Words per page')
-						.addOption(PageCountType.ByChars, 'Characters per page')
+						.addOption(PageCountType.ByWords, "Words per page")
+						.addOption(PageCountType.ByChars, "Characters per page")
 						.setValue(this.plugin.settings.pageCountType)
 						.onChange(async (value: PageCountType) => {
 							this.plugin.settings.pageCountType = value;
@@ -627,20 +627,20 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : 'red';
+					txt.inputEl.style.borderColor = isValid ? null : "red";
 
 					this.plugin.settings.wordsPerMinute = isValid ? Number(value) : 265;
 					await this.plugin.saveSettings();
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName('Words per minute')
+					.setName("Words per minute")
 					.setDesc(
-						'Used to calculate Reading Time. 265 is the average speed of an English-speaking adult.'
+						"Used to calculate Reading Time. 265 is the average speed of an English-speaking adult."
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder('265')
+							.setPlaceholder("265")
 							.setValue(this.plugin.settings.wordsPerMinute.toString())
 							.onChange(debounce(wordsPerMinuteChanged.bind(this, txt), 1000));
 					});
@@ -658,20 +658,20 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : 'red';
+					txt.inputEl.style.borderColor = isValid ? null : "red";
 
 					this.plugin.settings.charsPerMinute = isValid ? Number(value) : 500;
 					await this.plugin.saveSettings();
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName('Characters per minute')
+					.setName("Characters per minute")
 					.setDesc(
-						'Used to calculate Reading Time. 500 is the average speed for CJK texts.'
+						"Used to calculate Reading Time. 500 is the average speed for CJK texts."
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder('500')
+							.setPlaceholder("500")
 							.setValue(this.plugin.settings.charsPerMinute.toString())
 							.onChange(debounce(charsPerMinuteChanged.bind(this, txt), 1000));
 					});
@@ -687,20 +687,20 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : 'red';
+					txt.inputEl.style.borderColor = isValid ? null : "red";
 
 					this.plugin.settings.wordsPerPage = isValid ? Number(value) : 300;
 					await this.plugin.saveSettings();
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName('Words per page')
+					.setName("Words per page")
 					.setDesc(
-						'Used for page count. 300 is standard in English language publishing.'
+						"Used for page count. 300 is standard in English language publishing."
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder('300')
+							.setPlaceholder("300")
 							.setValue(this.plugin.settings.wordsPerPage.toString())
 							.onChange(debounce(wordsPerPageChanged.bind(this, txt), 1000));
 					});
@@ -710,7 +710,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 			if (this.plugin.settings.pageCountType === PageCountType.ByChars) {
 				new Setting(containerEl)
-					.setName('Include whitespace characters in page count')
+					.setName("Include whitespace characters in page count")
 					.addToggle((toggle) =>
 						toggle
 							.setValue(this.plugin.settings.charsPerPageIncludesWhitespace)
@@ -732,7 +732,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : 'red';
+					txt.inputEl.style.borderColor = isValid ? null : "red";
 
 					const defaultCharsPerPage = 1500;
 					this.plugin.settings.charsPerPage = isValid
@@ -742,17 +742,17 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName('Characters per page')
+					.setName("Characters per page")
 					.setDesc(
 						`Used for page count. ${
 							this.plugin.settings.charsPerPageIncludesWhitespace
-								? '2400 is common in Danish.'
-								: '1500 is common in German (Normseite).'
+								? "2400 is common in Danish."
+								: "1500 is common in German (Normseite)."
 						}`
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder('1500')
+							.setPlaceholder("1500")
 							.setValue(this.plugin.settings.charsPerPage.toString())
 							.onChange(debounce(charsPerPageChanged.bind(this, txt), 1000));
 					});
@@ -761,8 +761,8 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// DEBUG MODE
 
 			new Setting(containerEl)
-				.setName('Debug mode')
-				.setDesc('Log debugging information to the developer console')
+				.setName("Debug mode")
+				.setDesc("Log debugging information to the developer console")
 				.addToggle((toggle) =>
 					toggle
 						.setValue(this.plugin.settings.debugMode)
@@ -777,28 +777,28 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	}
 
 	private renderReanalyzeButton(containerEl: HTMLElement): void {
-		containerEl.createEl('hr');
+		containerEl.createEl("hr");
 
 		// REANALYZE
 
 		new Setting(containerEl)
 			.setHeading()
-			.setName('Reanalyze all documents')
+			.setName("Reanalyze all documents")
 			.setDesc(
-				'If changes have occurred outside of Obsidian, you may need to trigger a manual analysis'
+				"If changes have occurred outside of Obsidian, you may need to trigger a manual analysis"
 			)
 			.addButton((button) =>
 				button
-					.setButtonText('Reanalyze')
+					.setButtonText("Reanalyze")
 					.setCta()
 					.onClick(async () => {
 						button.disabled = true;
 						await this.plugin.initialize();
-						button.setButtonText('Done');
+						button.setButtonText("Done");
 						button.removeCta();
 
 						setTimeout(() => {
-							button.setButtonText('Reanalyze');
+							button.setButtonText("Reanalyze");
 							button.setCta();
 							button.disabled = false;
 						}, 1000);

--- a/logic/settings.ts
+++ b/logic/settings.ts
@@ -1,66 +1,66 @@
-import type NovelWordCountPlugin from "main";
+import type NovelWordCountPlugin from 'main';
 import {
 	App,
 	PluginSettingTab,
 	Setting,
 	TextComponent,
 	debounce,
-} from "obsidian";
+} from 'obsidian';
 
 export enum CountType {
-	None = "none",
-	Word = "word",
-	Page = "page",
-	PageDecimal = "pagedecimal",
-	ReadTime = "readtime",
-	PercentGoal = "percentgoal",
-	Note = "note",
-	Character = "character",
-	Link = "link",
-	Embed = "embed",
-	Alias = "alias",
-	Created = "created",
-	Modified = "modified",
-	FileSize = "filesize",
+	None = 'none',
+	Word = 'word',
+	Page = 'page',
+	PageDecimal = 'pagedecimal',
+	ReadTime = 'readtime',
+	PercentGoal = 'percentgoal',
+	Note = 'note',
+	Character = 'character',
+	Link = 'link',
+	Embed = 'embed',
+	Alias = 'alias',
+	Created = 'created',
+	Modified = 'modified',
+	FileSize = 'filesize',
 }
 
 export const COUNT_TYPE_DISPLAY_STRINGS: { [countType: string]: string } = {
-	[CountType.None]: "None",
-	[CountType.Word]: "Word Count",
-	[CountType.Page]: "Page Count",
-	[CountType.PageDecimal]: "Page Count (decimal)",
-	[CountType.ReadTime]: "Reading Time",
-	[CountType.PercentGoal]: "% of Word Goal",
-	[CountType.Note]: "Note Count",
-	[CountType.Character]: "Character Count",
-	[CountType.Link]: "Link Count",
-	[CountType.Embed]: "Embed Count",
-	[CountType.Alias]: "First Alias",
-	[CountType.Created]: "Created Date",
-	[CountType.Modified]: "Last Updated Date",
-	[CountType.FileSize]: "File Size",
+	[CountType.None]: 'None',
+	[CountType.Word]: 'Word Count',
+	[CountType.Page]: 'Page Count',
+	[CountType.PageDecimal]: 'Page Count (decimal)',
+	[CountType.ReadTime]: 'Reading Time',
+	[CountType.PercentGoal]: '% of Word Goal',
+	[CountType.Note]: 'Note Count',
+	[CountType.Character]: 'Character Count',
+	[CountType.Link]: 'Link Count',
+	[CountType.Embed]: 'Embed Count',
+	[CountType.Alias]: 'First Alias',
+	[CountType.Created]: 'Created Date',
+	[CountType.Modified]: 'Last Updated Date',
+	[CountType.FileSize]: 'File Size',
 };
 
 export const COUNT_TYPE_DESCRIPTIONS: { [countType: string]: string } = {
-	[CountType.None]: "Hidden.",
-	[CountType.Word]: "Total words.",
-	[CountType.Page]: "Total pages, rounded up.",
+	[CountType.None]: 'Hidden.',
+	[CountType.Word]: 'Total words.',
+	[CountType.Page]: 'Total pages, rounded up.',
 	[CountType.PageDecimal]:
-		"Total pages, precise to 2 digits after the decimal.",
-	[CountType.ReadTime]: "Estimated time to read the note.",
+		'Total pages, precise to 2 digits after the decimal.',
+	[CountType.ReadTime]: 'Estimated time to read the note.',
 	[CountType.PercentGoal]:
 		"Set a word goal by adding the 'word-goal' property to a note.",
-	[CountType.Note]: "Total notes.",
+	[CountType.Note]: 'Total notes.',
 	[CountType.Character]:
-		"Total characters (letters, symbols, numbers, and spaces).",
-	[CountType.Link]: "Total links to other notes.",
-	[CountType.Embed]: "Total embedded images, files, and notes.",
-	[CountType.Alias]: "The first alias property of each note.",
+		'Total characters (letters, symbols, numbers, and spaces).',
+	[CountType.Link]: 'Total links to other notes.',
+	[CountType.Embed]: 'Total embedded images, files, and notes.',
+	[CountType.Alias]: 'The first alias property of each note.',
 	[CountType.Created]:
-		"Creation date. (On folders: earliest creation date of any note.)",
+		'Creation date. (On folders: earliest creation date of any note.)',
 	[CountType.Modified]:
-		"Date of last edit. (On folders: latest edit date of any note.)",
-	[CountType.FileSize]: "Total size on hard drive.",
+		'Date of last edit. (On folders: latest edit date of any note.)',
+	[CountType.FileSize]: 'Total size on hard drive.',
 };
 
 export const UNFORMATTABLE_COUNT_TYPES = [
@@ -69,17 +69,19 @@ export const UNFORMATTABLE_COUNT_TYPES = [
 	CountType.FileSize,
 	CountType.ReadTime,
 ];
-export const COUNT_TYPE_DEFAULT_SHORT_SUFFIXES: { [countType: string]: string } = {
-	[CountType.Word]: "w",
-	[CountType.Page]: "p",
-	[CountType.PageDecimal]: "p",
-	[CountType.PercentGoal]: "%",
-	[CountType.Note]: "n",
-	[CountType.Character]: "ch",
-	[CountType.Link]: "x",
-	[CountType.Embed]: "em",
-	[CountType.Created]: "/c",
-	[CountType.Modified]: "/u",
+export const COUNT_TYPE_DEFAULT_SHORT_SUFFIXES: {
+	[countType: string]: string;
+} = {
+	[CountType.Word]: 'w',
+	[CountType.Page]: 'p',
+	[CountType.PageDecimal]: 'p',
+	[CountType.PercentGoal]: '%',
+	[CountType.Note]: 'n',
+	[CountType.Character]: 'ch',
+	[CountType.Link]: 'x',
+	[CountType.Embed]: 'em',
+	[CountType.Created]: '/c',
+	[CountType.Modified]: '/u',
 };
 
 export function getDescription(countType: CountType): string {
@@ -104,9 +106,9 @@ export const COUNT_TYPES = [
 ];
 
 export enum AlignmentType {
-	Inline = "inline",
-	Right = "right",
-	Below = "below",
+	Inline = 'inline',
+	Right = 'right',
+	Below = 'below',
 }
 
 export const ALIGNMENT_TYPES = [
@@ -116,19 +118,19 @@ export const ALIGNMENT_TYPES = [
 ];
 
 export enum CharacterCountType {
-	StringLength = "AllCharacters",
-	ExcludeWhitespace = "ExcludeWhitespace",
+	StringLength = 'AllCharacters',
+	ExcludeWhitespace = 'ExcludeWhitespace',
 }
 
 export enum WordCountType {
-	SpaceDelimited = "SpaceDelimited",
-	CJK = "CJK",
-	AutoDetect = "AutoDetect",
+	SpaceDelimited = 'SpaceDelimited',
+	CJK = 'CJK',
+	AutoDetect = 'AutoDetect',
 }
 
 export enum PageCountType {
-	ByWords = "ByWords",
-	ByChars = "ByChars",
+	ByWords = 'ByWords',
+	ByChars = 'ByChars',
 }
 
 export interface NovelWordCountSettings {
@@ -165,6 +167,7 @@ export interface NovelWordCountSettings {
 	characterCountType: CharacterCountType;
 	wordCountType: WordCountType;
 	pageCountType: PageCountType;
+	includeDirectories: string;
 	excludeComments: boolean;
 	debugMode: boolean;
 }
@@ -174,23 +177,23 @@ export const DEFAULT_SETTINGS: NovelWordCountSettings = {
 	useAdvancedFormatting: false,
 	// NOTES
 	countType: CountType.Word,
-	countTypeSuffix: "w",
+	countTypeSuffix: 'w',
 	countType2: CountType.None,
-	countType2Suffix: "",
+	countType2Suffix: '',
 	countType3: CountType.None,
-	countType3Suffix: "",
-	pipeSeparator: "|",
+	countType3Suffix: '',
+	pipeSeparator: '|',
 	abbreviateDescriptions: false,
 	alignment: AlignmentType.Inline,
 	// FOLDERS
 	showSameCountsOnFolders: true,
 	folderCountType: CountType.Word,
-	folderCountTypeSuffix: "w",
+	folderCountTypeSuffix: 'w',
 	folderCountType2: CountType.None,
-	folderCountType2Suffix: "",
+	folderCountType2Suffix: '',
 	folderCountType3: CountType.None,
-	folderCountType3Suffix: "",
-	folderPipeSeparator: "|",
+	folderCountType3Suffix: '',
+	folderPipeSeparator: '|',
 	folderAbbreviateDescriptions: false,
 	folderAlignment: AlignmentType.Inline,
 	// ADVANCED
@@ -203,6 +206,7 @@ export const DEFAULT_SETTINGS: NovelWordCountSettings = {
 	characterCountType: CharacterCountType.StringLength,
 	wordCountType: WordCountType.SpaceDelimited,
 	pageCountType: PageCountType.ByWords,
+	includeDirectories: '',
 	excludeComments: false,
 	debugMode: false,
 };
@@ -231,21 +235,21 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	//
 
 	private renderNoteSettings(containerEl: HTMLElement): void {
-		const mainHeader = containerEl.createEl("div", {
+		const mainHeader = containerEl.createEl('div', {
 			cls: [
-				"setting-item",
-				"setting-item-heading",
-				"novel-word-count-settings-header",
+				'setting-item',
+				'setting-item-heading',
+				'novel-word-count-settings-header',
 			],
 		});
-		mainHeader.createEl("div", { text: "Notes" });
-		mainHeader.createEl("div", {
-			text: "You can display up to three data types side by side.",
-			cls: "setting-item-description",
+		mainHeader.createEl('div', { text: 'Notes' });
+		mainHeader.createEl('div', {
+			text: 'You can display up to three data types side by side.',
+			cls: 'setting-item-description',
 		});
 
 		new Setting(containerEl)
-			.setDesc("Use advanced formatting")
+			.setDesc('Use advanced formatting')
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.useAdvancedFormatting)
@@ -260,7 +264,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - DATA TYPE 1
 
 		this.renderCountTypeSetting(containerEl, {
-			name: "1st data type to show",
+			name: '1st data type to show',
 			oldCountType: this.plugin.settings.countType,
 			setNewCountType: (value) => {
 				this.plugin.settings.countType = value;
@@ -278,7 +282,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - DATA TYPE 2
 
 		this.renderCountTypeSetting(containerEl, {
-			name: "2nd data type to show",
+			name: '2nd data type to show',
 			oldCountType: this.plugin.settings.countType2,
 			setNewCountType: (value) => {
 				this.plugin.settings.countType2 = value;
@@ -296,7 +300,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - DATA TYPE 3
 
 		this.renderCountTypeSetting(containerEl, {
-			name: "3rd data type to show",
+			name: '3rd data type to show',
 			oldCountType: this.plugin.settings.countType3,
 			setNewCountType: (value) => {
 				this.plugin.settings.countType3 = value;
@@ -313,7 +317,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 		// NOTE - SEPARATOR
 		if (this.plugin.settings.useAdvancedFormatting) {
-			new Setting(containerEl).setName("Data type separator").addText((text) =>
+			new Setting(containerEl).setName('Data type separator').addText((text) =>
 				text
 					.setValue(this.plugin.settings.pipeSeparator)
 					.onChange(async (value) => {
@@ -328,7 +332,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 		if (!this.plugin.settings.useAdvancedFormatting) {
 			new Setting(containerEl)
-				.setName("Abbreviate descriptions")
+				.setName('Abbreviate descriptions')
 				.setDesc("E.g. show '120w' instead of '120 words'")
 				.addToggle((toggle) =>
 					toggle
@@ -344,15 +348,15 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 		// NOTE - ALIGNMENT
 
 		new Setting(containerEl)
-			.setName("Alignment")
+			.setName('Alignment')
 			.setDesc(
-				"Show data inline with file/folder names, right-aligned, or underneath"
+				'Show data inline with file/folder names, right-aligned, or underneath'
 			)
 			.addDropdown((drop) => {
 				drop
-					.addOption(AlignmentType.Inline, "Inline")
-					.addOption(AlignmentType.Right, "Right-aligned")
-					.addOption(AlignmentType.Below, "Below")
+					.addOption(AlignmentType.Inline, 'Inline')
+					.addOption(AlignmentType.Right, 'Right-aligned')
+					.addOption(AlignmentType.Below, 'Below')
 					.setValue(this.plugin.settings.alignment)
 					.onChange(async (value: AlignmentType) => {
 						this.plugin.settings.alignment = value;
@@ -363,13 +367,13 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	}
 
 	private renderFolderSettings(containerEl: HTMLElement): void {
-		containerEl.createEl("hr");
+		containerEl.createEl('hr');
 
 		// SHOW SAME DATA ON FOLDERS
 
 		new Setting(containerEl)
 			.setHeading()
-			.setName("Folders: Same data as Notes")
+			.setName('Folders: Same data as Notes')
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.showSameCountsOnFolders)
@@ -386,12 +390,14 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - DATA TYPE 1
 
 			this.renderCountTypeSetting(containerEl, {
-				name: "1st data type to show",
+				name: '1st data type to show',
 				oldCountType: this.plugin.settings.folderCountType,
 				setNewCountType: (value) => {
 					this.plugin.settings.folderCountType = value;
 					this.plugin.settings.folderCountTypeSuffix =
-						COUNT_TYPE_DEFAULT_SHORT_SUFFIXES[this.plugin.settings.folderCountType];
+						COUNT_TYPE_DEFAULT_SHORT_SUFFIXES[
+							this.plugin.settings.folderCountType
+						];
 				},
 			});
 
@@ -405,12 +411,14 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - DATA TYPE 2
 
 			this.renderCountTypeSetting(containerEl, {
-				name: "2nd data type to show",
+				name: '2nd data type to show',
 				oldCountType: this.plugin.settings.folderCountType2,
 				setNewCountType: (value) => {
 					this.plugin.settings.folderCountType2 = value;
 					this.plugin.settings.folderCountType2Suffix =
-						COUNT_TYPE_DEFAULT_SHORT_SUFFIXES[this.plugin.settings.folderCountType2];
+						COUNT_TYPE_DEFAULT_SHORT_SUFFIXES[
+							this.plugin.settings.folderCountType2
+						];
 				},
 			});
 
@@ -424,12 +432,14 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - DATA TYPE 3
 
 			this.renderCountTypeSetting(containerEl, {
-				name: "3rd data type to show",
+				name: '3rd data type to show',
 				oldCountType: this.plugin.settings.folderCountType3,
 				setNewCountType: (value) => {
 					this.plugin.settings.folderCountType3 = value;
 					this.plugin.settings.folderCountType3Suffix =
-						COUNT_TYPE_DEFAULT_SHORT_SUFFIXES[this.plugin.settings.folderCountType3];
+						COUNT_TYPE_DEFAULT_SHORT_SUFFIXES[
+							this.plugin.settings.folderCountType3
+						];
 				},
 			});
 
@@ -443,7 +453,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// FOLDER - SEPARATOR
 			if (this.plugin.settings.useAdvancedFormatting) {
 				new Setting(containerEl)
-					.setName("Data type separator")
+					.setName('Data type separator')
 					.addText((text) =>
 						text
 							.setValue(this.plugin.settings.folderPipeSeparator)
@@ -459,7 +469,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 			if (!this.plugin.settings.useAdvancedFormatting) {
 				new Setting(containerEl)
-					.setName("Abbreviate descriptions")
+					.setName('Abbreviate descriptions')
 					.addToggle((toggle) =>
 						toggle
 							.setValue(this.plugin.settings.folderAbbreviateDescriptions)
@@ -473,11 +483,11 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 			// FOLDER - ALIGNMENT
 
-			new Setting(containerEl).setName("Alignment").addDropdown((drop) => {
+			new Setting(containerEl).setName('Alignment').addDropdown((drop) => {
 				drop
-					.addOption(AlignmentType.Inline, "Inline")
-					.addOption(AlignmentType.Right, "Right-aligned")
-					.addOption(AlignmentType.Below, "Below")
+					.addOption(AlignmentType.Inline, 'Inline')
+					.addOption(AlignmentType.Right, 'Right-aligned')
+					.addOption(AlignmentType.Below, 'Below')
 					.setValue(this.plugin.settings.folderAlignment)
 					.onChange(async (value: AlignmentType) => {
 						this.plugin.settings.folderAlignment = value;
@@ -489,12 +499,12 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	}
 
 	private renderAdvancedSettings(containerEl: HTMLElement): void {
-		containerEl.createEl("hr");
+		containerEl.createEl('hr');
 
 		new Setting(containerEl)
 			.setHeading()
-			.setName("Show advanced options")
-			.setDesc("Language compatibility and fine-tuning")
+			.setName('Show advanced options')
+			.setDesc('Language compatibility and fine-tuning')
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.showAdvanced)
@@ -506,12 +516,30 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			);
 
 		if (this.plugin.settings.showAdvanced) {
+			// INCLUDE DIRECTORIES
+
+			new Setting(containerEl)
+				.setName('Include directories')
+				.setDesc(
+					'Only include specific directories. Defaults to all directories. Can be used to exclude directories from displaying counts.'
+				)
+				.addText((txt) => {
+					txt
+						.setPlaceholder('')
+						.setValue(this.plugin.settings.includeDirectories.toString())
+						.onChange(async (value) => {
+							this.plugin.settings.includeDirectories = value;
+							await this.plugin.saveSettings();
+							await this.plugin.initialize();
+						});
+				});
+
 			// EXCLUDE COMMENTS
 
 			new Setting(containerEl)
-				.setName("Exclude comments")
+				.setName('Exclude comments')
 				.setDesc(
-					"Exclude %%Obsidian%% and <!--HTML--> comments from counts. May affect performance on large vaults."
+					'Exclude %%Obsidian%% and <!--HTML--> comments from counts. May affect performance on large vaults.'
 				)
 				.addToggle((toggle) =>
 					toggle
@@ -526,14 +554,14 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// CHARACTER COUNT METHOD
 
 			new Setting(containerEl)
-				.setName("Character count method")
-				.setDesc("For language compatibility")
+				.setName('Character count method')
+				.setDesc('For language compatibility')
 				.addDropdown((drop) => {
 					drop
-						.addOption(CharacterCountType.StringLength, "All characters")
+						.addOption(CharacterCountType.StringLength, 'All characters')
 						.addOption(
 							CharacterCountType.ExcludeWhitespace,
-							"Exclude whitespace"
+							'Exclude whitespace'
 						)
 						.setValue(this.plugin.settings.characterCountType)
 						.onChange(async (value: CharacterCountType) => {
@@ -546,16 +574,16 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// WORD COUNT METHOD
 
 			new Setting(containerEl)
-				.setName("Word count method")
-				.setDesc("For language compatibility")
+				.setName('Word count method')
+				.setDesc('For language compatibility')
 				.addDropdown((drop) => {
 					drop
 						.addOption(
 							WordCountType.SpaceDelimited,
-							"Space-delimited (European languages)"
+							'Space-delimited (European languages)'
 						)
-						.addOption(WordCountType.CJK, "Han/Kana/Hangul (CJK)")
-						.addOption(WordCountType.AutoDetect, "Auto-detect by file")
+						.addOption(WordCountType.CJK, 'Han/Kana/Hangul (CJK)')
+						.addOption(WordCountType.AutoDetect, 'Auto-detect by file')
 						.setValue(this.plugin.settings.wordCountType)
 						.onChange(async (value: WordCountType) => {
 							this.plugin.settings.wordCountType = value;
@@ -569,12 +597,12 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// PAGE COUNT METHOD
 
 			new Setting(containerEl)
-				.setName("Page count method")
-				.setDesc("For language compatibility")
+				.setName('Page count method')
+				.setDesc('For language compatibility')
 				.addDropdown((drop) => {
 					drop
-						.addOption(PageCountType.ByWords, "Words per page")
-						.addOption(PageCountType.ByChars, "Characters per page")
+						.addOption(PageCountType.ByWords, 'Words per page')
+						.addOption(PageCountType.ByChars, 'Characters per page')
 						.setValue(this.plugin.settings.pageCountType)
 						.onChange(async (value: PageCountType) => {
 							this.plugin.settings.pageCountType = value;
@@ -599,20 +627,20 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : "red";
+					txt.inputEl.style.borderColor = isValid ? null : 'red';
 
 					this.plugin.settings.wordsPerMinute = isValid ? Number(value) : 265;
 					await this.plugin.saveSettings();
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName("Words per minute")
+					.setName('Words per minute')
 					.setDesc(
-						"Used to calculate Reading Time. 265 is the average speed of an English-speaking adult."
+						'Used to calculate Reading Time. 265 is the average speed of an English-speaking adult.'
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder("265")
+							.setPlaceholder('265')
 							.setValue(this.plugin.settings.wordsPerMinute.toString())
 							.onChange(debounce(wordsPerMinuteChanged.bind(this, txt), 1000));
 					});
@@ -630,20 +658,20 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : "red";
+					txt.inputEl.style.borderColor = isValid ? null : 'red';
 
 					this.plugin.settings.charsPerMinute = isValid ? Number(value) : 500;
 					await this.plugin.saveSettings();
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName("Characters per minute")
+					.setName('Characters per minute')
 					.setDesc(
-						"Used to calculate Reading Time. 500 is the average speed for CJK texts."
+						'Used to calculate Reading Time. 500 is the average speed for CJK texts.'
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder("500")
+							.setPlaceholder('500')
 							.setValue(this.plugin.settings.charsPerMinute.toString())
 							.onChange(debounce(charsPerMinuteChanged.bind(this, txt), 1000));
 					});
@@ -659,20 +687,20 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : "red";
+					txt.inputEl.style.borderColor = isValid ? null : 'red';
 
 					this.plugin.settings.wordsPerPage = isValid ? Number(value) : 300;
 					await this.plugin.saveSettings();
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName("Words per page")
+					.setName('Words per page')
 					.setDesc(
-						"Used for page count. 300 is standard in English language publishing."
+						'Used for page count. 300 is standard in English language publishing.'
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder("300")
+							.setPlaceholder('300')
 							.setValue(this.plugin.settings.wordsPerPage.toString())
 							.onChange(debounce(wordsPerPageChanged.bind(this, txt), 1000));
 					});
@@ -682,7 +710,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 
 			if (this.plugin.settings.pageCountType === PageCountType.ByChars) {
 				new Setting(containerEl)
-					.setName("Include whitespace characters in page count")
+					.setName('Include whitespace characters in page count')
 					.addToggle((toggle) =>
 						toggle
 							.setValue(this.plugin.settings.charsPerPageIncludesWhitespace)
@@ -704,7 +732,7 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					const asNumber = Number(value);
 					const isValid = !isNaN(asNumber) && asNumber > 0;
 
-					txt.inputEl.style.borderColor = isValid ? null : "red";
+					txt.inputEl.style.borderColor = isValid ? null : 'red';
 
 					const defaultCharsPerPage = 1500;
 					this.plugin.settings.charsPerPage = isValid
@@ -714,17 +742,17 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 					await this.plugin.initialize();
 				};
 				new Setting(containerEl)
-					.setName("Characters per page")
+					.setName('Characters per page')
 					.setDesc(
 						`Used for page count. ${
 							this.plugin.settings.charsPerPageIncludesWhitespace
-								? "2400 is common in Danish."
-								: "1500 is common in German (Normseite)."
+								? '2400 is common in Danish.'
+								: '1500 is common in German (Normseite).'
 						}`
 					)
 					.addText((txt) => {
 						txt
-							.setPlaceholder("1500")
+							.setPlaceholder('1500')
 							.setValue(this.plugin.settings.charsPerPage.toString())
 							.onChange(debounce(charsPerPageChanged.bind(this, txt), 1000));
 					});
@@ -733,8 +761,8 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 			// DEBUG MODE
 
 			new Setting(containerEl)
-				.setName("Debug mode")
-				.setDesc("Log debugging information to the developer console")
+				.setName('Debug mode')
+				.setDesc('Log debugging information to the developer console')
 				.addToggle((toggle) =>
 					toggle
 						.setValue(this.plugin.settings.debugMode)
@@ -749,28 +777,28 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 	}
 
 	private renderReanalyzeButton(containerEl: HTMLElement): void {
-		containerEl.createEl("hr");
+		containerEl.createEl('hr');
 
 		// REANALYZE
 
 		new Setting(containerEl)
 			.setHeading()
-			.setName("Reanalyze all documents")
+			.setName('Reanalyze all documents')
 			.setDesc(
-				"If changes have occurred outside of Obsidian, you may need to trigger a manual analysis"
+				'If changes have occurred outside of Obsidian, you may need to trigger a manual analysis'
 			)
 			.addButton((button) =>
 				button
-					.setButtonText("Reanalyze")
+					.setButtonText('Reanalyze')
 					.setCta()
 					.onClick(async () => {
 						button.disabled = true;
 						await this.plugin.initialize();
-						button.setButtonText("Done");
+						button.setButtonText('Done');
 						button.removeCta();
 
 						setTimeout(() => {
-							button.setButtonText("Reanalyze");
+							button.setButtonText('Reanalyze');
 							button.setCta();
 							button.disabled = false;
 						}, 1000);


### PR DESCRIPTION
It would be nice if we could explicitly include directories. I have a Vault with mixed uses, one of them being writing, and I'd like to only include my "Writing" directory. The changes here are more of a proof-of-concept, but they work. If you'd consider supporting this feature and want me to flesh this out a bit more I can.

![CleanShot 2023-12-01 at 09 26 13](https://github.com/isaaclyman/novel-word-count-obsidian/assets/7103990/4636c063-9179-40b1-9c9c-83cffb384e80)


Apologies for some of the formatting changes. If you have other prettier settings outside of `.prettierrc` I can rework these changes to adhere to style guidelines.