### PR TITLE
Replace var declaration with let declaration

### DIFF
--- a/logic/debug.ts
+++ b/logic/debug.ts
@@ -26,7 +26,7 @@ export class DebugHelper {
 			return () => {}
 		}
 
-		var qualifiedName = `novel-word-count|${name}`
+		let qualifiedName = `novel-word-count|${name}`
 		console.time(qualifiedName);
 		return () => console.timeEnd(qualifiedName);
 	}


### PR DESCRIPTION
Replaces `var` declaration with `let` declaration. `let` is used much more frequently in this repository.