### PR TITLE
Add a negative lookup in regex to block bugged matches when URL string is empty

### DIFF
--- a/logic/parser.ts
+++ b/logic/parser.ts
@@ -61,7 +61,7 @@ export function removeNonCountedContent(
 
   if (config.excludeNonVisibleLinkPortions) {
     // Exclude the URL of external links
-    content = content.replace(/\[(.+?)\]\(.+?\)/gim, "$1");
+    content = content.replace(/\[(.+?)\]\((?!\)).+?\)/gim, "$1");
 
     // Exclude the note name of internal links with an alias
     content = content.replace(/\[\[.+?\|(.+?)\]\]/gim, "$1");


### PR DESCRIPTION
Having an empty link text and a closing bracket `)` later in the same line, causes the words in-between to get matched in the Regex and therefore, ignored in the count.

For example, for the text: `foo [bar]() baz foo )`, the `baz foo` portion will also get picked up.