### PR TITLE
Added a config to exclude footnotes

### DIFF
--- a/logic/file.ts
+++ b/logic/file.ts
@@ -255,6 +255,7 @@ export class FileHelper {
 			excludeComments: this.settings.excludeComments,
 			excludeNonVisibleLinkPortions:
 				this.settings.excludeNonVisibleLinkPortions,
+			excludeFootnotes: this.settings.excludeFootnotes,
 		});
 		const combinedWordCount =
 			countResult.cjkWordCount + countResult.spaceDelimitedWordCount;

--- a/logic/parser-obsidian.ts
+++ b/logic/parser-obsidian.ts
@@ -6,7 +6,8 @@ export function countMarkdownObsidian(content: string): MarkdownParseResult {
   content = removeNonCountedContent(content, {
     excludeCodeBlocks: true,
     excludeComments: true,
-    excludeNonVisibleLinkPortions: true
+    excludeNonVisibleLinkPortions: true,
+    excludeFootnotes: true,
   });
 
   const result: MarkdownParseResult = {

--- a/logic/parser.ts
+++ b/logic/parser.ts
@@ -2,6 +2,7 @@ export interface MarkdownParseConfig {
 	excludeComments: boolean;
 	excludeCodeBlocks: boolean;
 	excludeNonVisibleLinkPortions: boolean;
+	excludeFootnotes: boolean;
 }
 
 export interface MarkdownParseResult {
@@ -67,6 +68,14 @@ export function removeNonCountedContent(
 		content = content.replace(/\[\[(.*?)\]\]/gim, (_, $1) => {
 			return !$1 ? "" : $1.includes("|") ? $1.slice($1.indexOf("|") + 1) : $1;
 		});
+	}
+
+	if (config.excludeFootnotes) {
+		// Replace the footnotes
+		content = content.replace(/\[\^.+?\]: .*/gim, "");
+
+		// Replace the footnote marks
+		content = content.replace(/\[\^.+?\]/gim, "");
 	}
 
 	return content;

--- a/logic/settings.ts
+++ b/logic/settings.ts
@@ -587,9 +587,9 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 				);
 
 			new Setting(containerEl)
-				.setName("Exclude markdown footnotes")
+				.setName("Exclude footnotes")
 				.setDesc(
-					"Exclude markdown footnotes as per this specification https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/"
+					"Exclude footnotes[^1] from counts. May affect performance on large vaults."
 				)
 				.addToggle((toggle) =>
 					toggle

--- a/logic/settings.ts
+++ b/logic/settings.ts
@@ -164,6 +164,7 @@ export interface NovelWordCountSettings {
 	excludeComments: boolean;
 	excludeCodeBlocks: boolean;
 	excludeNonVisibleLinkPortions: boolean;
+	excludeFootnotes: boolean;
 	debugMode: boolean;
 }
 
@@ -204,6 +205,7 @@ export const DEFAULT_SETTINGS: NovelWordCountSettings = {
 	excludeComments: false,
 	excludeCodeBlocks: false,
 	excludeNonVisibleLinkPortions: false,
+	excludeFootnotes: false,
 	debugMode: false,
 };
 
@@ -579,6 +581,21 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 						.setValue(this.plugin.settings.excludeNonVisibleLinkPortions)
 						.onChange(async (value) => {
 							this.plugin.settings.excludeNonVisibleLinkPortions = value;
+							await this.plugin.saveSettings();
+							await this.plugin.initialize();
+						})
+				);
+
+			new Setting(containerEl)
+				.setName("Exclude markdown footnotes")
+				.setDesc(
+					"Exclude markdown footnotes as per this specification https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/"
+				)
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.excludeFootnotes)
+						.onChange(async (value) => {
+							this.plugin.settings.excludeFootnotes = value;
 							await this.plugin.saveSettings();
 							await this.plugin.initialize();
 						})

--- a/test/parser.benchmark.test.ts
+++ b/test/parser.benchmark.test.ts
@@ -48,7 +48,8 @@ describe('parser benchmark', () => {
       const result = countMarkdown(words500, {
         excludeCodeBlocks: true,
         excludeComments: true,
-        excludeNonVisibleLinkPortions: true
+        excludeNonVisibleLinkPortions: true,
+        excludeFootnotes: true,
       });
     }
     console.timeEnd(label);
@@ -74,7 +75,8 @@ describe('parser benchmark', () => {
     const result = countMarkdown(words500.repeat(10_000), {
       excludeCodeBlocks: true,
       excludeComments: true,
-      excludeNonVisibleLinkPortions: true
+      excludeNonVisibleLinkPortions: true,
+      excludeFootnotes: true,
     });
     console.timeEnd(label);
   });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -5,6 +5,7 @@ const countMarkdown = (content: string) =>
 		excludeCodeBlocks: true,
 		excludeComments: true,
 		excludeNonVisibleLinkPortions: true,
+		excludeFootnotes: true,
 	});
 
 describe("parseMarkdown", () => {
@@ -625,6 +626,57 @@ select * from blah blah blah
 			expect(result.charCount).toBe(45);
 			expect(result.nonWhitespaceCharCount).toBe(37);
 			expect(result.spaceDelimitedWordCount).toBe(7);
+			expect(result.cjkWordCount).toBe(0);
+		});
+	});
+
+	describe("footnotes", () => {
+		it("ignores numeric footnotes", () => {
+			const content = `
+Here's a footnote mark[^7]!
+
+[^7]: This is the footnote itself
+			`;
+
+			const result = countMarkdown(content);
+
+			expect(result.charCount).toBe(30);
+			expect(result.nonWhitespaceCharCount).toBe(20);
+			expect(result.spaceDelimitedWordCount).toBe(4);
+			expect(result.cjkWordCount).toBe(0);
+		});
+
+		it("ignores string footnotes", () => {
+			const content = `
+Here's a footnote mark with a string[^some-string]!
+
+[^some-string]: This is the footnote itself
+			`;
+
+			const result = countMarkdown(content);
+
+			expect(result.charCount).toBe(44);
+			expect(result.nonWhitespaceCharCount).toBe(31);
+			expect(result.spaceDelimitedWordCount).toBe(7);
+			expect(result.cjkWordCount).toBe(0);
+		});
+
+		it("ignores multiple footnotes", () => {
+			const content = `
+Here's a footnote mark[^7]!
+Here's another *footnote mark[^8]*, and some content after.
+Here's a footnote mark with a string[^some-string]!
+
+[^7]: This is the footnote
+[^8]: This is the other footnote
+[^some-string]: This is the string footnote
+			`;
+
+			const result = countMarkdown(content);
+
+			expect(result.charCount).toBe(126);
+			expect(result.nonWhitespaceCharCount).toBe(99);
+			expect(result.spaceDelimitedWordCount).toBe(19);
 			expect(result.cjkWordCount).toBe(0);
 		});
 	});


### PR DESCRIPTION
I use some footnotes for info dumps in my novel :) Google Docs never counted them in the word count. So, when moving from it to Obsidian, I've decided that I need this config. Awesome plugin, by the way, many thanks.

Reasoning:
- Based on the article I *scanned*, they don't count footnotes in word count in academia https://wordcounter.net/blog/2016/04/15/101453_footnotes-word-count.html
- Google Docs doesn't do it either
- Keeps you from info-dumping all your daily word goal into those pesky footnotes

Feel free to ask me to add or remove anything :)