### PR TITLE
Fix: RTL text alignment issue with Arabian symbols in folder names

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,7 @@
 
 .novel-word-count--active .nav-files-container .nav-file-title {
   align-items: baseline;
+  unicode-bidi: isolate;
 }
 .novel-word-count--active .nav-files-container .nav-file-title::after {
   content: attr(data-novel-word-count-plugin);
@@ -33,9 +34,12 @@
   position: relative;
   text-overflow: ellipsis;
   white-space: nowrap;
+  unicode-bidi: isolate;
+  direction: ltr;
 }
 .novel-word-count--active .nav-files-container .nav-file-title-content {
   min-width: 20px;
+  unicode-bidi: isolate;
 }
 .novel-word-count--note-right .nav-files-container .nav-file-title-content {
   flex: 1 1 0;
@@ -62,6 +66,7 @@
 }
 .novel-word-count--active .nav-files-container .nav-folder-title {
   align-items: baseline;
+  unicode-bidi: isolate;
 }
 .novel-word-count--active .nav-files-container .nav-folder-title::after {
   content: attr(data-novel-word-count-plugin);
@@ -76,9 +81,12 @@
   position: relative;
   text-overflow: ellipsis;
   white-space: nowrap;
+  unicode-bidi: isolate;
+  direction: ltr;
 }
 .novel-word-count--active .nav-files-container .nav-folder-title-content {
   min-width: 20px;
+  unicode-bidi: isolate;
 }
 .novel-word-count--folder-right .nav-files-container .nav-folder-title-content {
   flex: 1 1 0;

--- a/styles.scss
+++ b/styles.scss
@@ -24,6 +24,8 @@
 	.nav-file-title {
     .novel-word-count--active & {
       align-items: baseline;
+      // Ensure proper text direction handling
+      unicode-bidi: isolate;
     }
 
 		.novel-word-count--active &::after {
@@ -39,10 +41,15 @@
 			position: relative;
 			text-overflow: ellipsis;
 			white-space: nowrap;
+			// Isolate the word count from RTL text influence
+			unicode-bidi: isolate;
+			direction: ltr;
 		}
 
 		.novel-word-count--active &-content {
 			min-width: 20px;
+			// Isolate file name from word count
+			unicode-bidi: isolate;
 		}
 
 		.novel-word-count--note-right &-content {
@@ -76,7 +83,9 @@
 
 	.nav-folder-title {
 		.novel-word-count--active & {
-			align-items: baseline;			
+			align-items: baseline;
+			// Ensure proper text direction handling
+			unicode-bidi: isolate;
 		}
 
 		.novel-word-count--active &::after {
@@ -92,6 +101,9 @@
 			position: relative;
 			text-overflow: ellipsis;
 			white-space: nowrap;
+			// Isolate the word count from RTL text influence
+			unicode-bidi: isolate;
+			direction: ltr;
 		}
 
 		.novel-word-count--active &-content {


### PR DESCRIPTION
  This PR fixes the folder alignment issue when Arabic or RTL characters are present in folder/file names.

  ## Problem
  When folder names contain Arabic or RTL (Right-to-Left) text, the entire folder element shifts to the right
   in the File Explorer, disrupting the layout.

  ## Solution
  Added CSS `unicode-bidi: isolate` property to properly isolate bidirectional text formatting:
  - Applied to `.nav-folder-title` and `.nav-file-title` elements to prevent RTL text from affecting parent
  layout
  - Added `direction: ltr` to word count `::after` pseudo-elements to ensure counts always display
  left-to-right
  - Isolated folder/file name content from word count display