### PR TITLE
Exclusion settings addition

### DIFF
--- a/logic/file.ts
+++ b/logic/file.ts
@@ -274,6 +274,7 @@ export class FileHelper {
 		const countResult = countMarkdown(content, {
 			excludeCodeBlocks: this.settings.excludeCodeBlocks,
 			excludeComments: this.settings.excludeComments,
+			excludeStrikethrough: this.settings.excludeStrikethrough,
 			excludeNonVisibleLinkPortions:
 				this.settings.excludeNonVisibleLinkPortions,
 			excludeFootnotes: this.settings.excludeFootnotes,
@@ -443,3 +444,6 @@ export class FileHelper {
 		return true;
 	}
 }
+export { TargetNode };
+export type { CountData };
+

--- a/logic/parser-obsidian.ts
+++ b/logic/parser-obsidian.ts
@@ -6,6 +6,7 @@ export function countMarkdownObsidian(content: string): MarkdownParseResult {
   content = removeNonCountedContent(content, {
     excludeCodeBlocks: true,
     excludeComments: true,
+    excludeStrikethrough: true,
     excludeNonVisibleLinkPortions: true,
     excludeFootnotes: true,
   });

--- a/logic/parser.ts
+++ b/logic/parser.ts
@@ -70,7 +70,7 @@ export function removeNonCountedContent(
 	}
 
 	if (config.excludeStrikethrough) {
-		content = content.replace(/(~~.+?~~|\n)/gims, "");
+		content = content.replace(/(~~.+?(~~|\n))/gims, "");
 	}
 
 	if (config.excludeNonVisibleLinkPortions) {

--- a/logic/parser.ts
+++ b/logic/parser.ts
@@ -1,6 +1,7 @@
 export interface MarkdownParseConfig {
 	excludeComments: boolean;
 	excludeCodeBlocks: boolean;
+	excludeStrikethrough: boolean;
 	excludeNonVisibleLinkPortions: boolean;
 	excludeFootnotes: boolean;
 }
@@ -61,11 +62,15 @@ export function removeNonCountedContent(
 	config: MarkdownParseConfig
 ): string {
 	if (config.excludeCodeBlocks) {
-		content = content.replace(/(```.+?```)/gims, "");
+		content = content.replace(/((```.+?(```|\n))|(`.+?(`|\n)))/gims, "");
 	}
 
 	if (config.excludeComments) {
-		content = content.replace(/(%%.+?%%|<!--.+?-->)/gims, "");
+		content = content.replace(/(%%.+?(%%|\n)|<!--.+?-->)/gims, "");
+	}
+
+	if (config.excludeStrikethrough) {
+		content = content.replace(/(~~.+?~~|\n)/gims, "");
 	}
 
 	if (config.excludeNonVisibleLinkPortions) {

--- a/logic/settings.tab.ts
+++ b/logic/settings.tab.ts
@@ -614,6 +614,22 @@ export class NovelWordCountSettingTab extends PluginSettingTab {
 						})
 				);
 
+			//exclude strikethrough
+			new Setting(containerEl)
+				.setName("Exclude strikethrough")
+				.setDesc(
+					"Exclude ~~strikethrough~~ from all counts. May affect performance on large vaults."
+				)
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.excludeStrikethrough)
+						.onChange(async (value) => {
+							this.plugin.settings.excludeStrikethrough = value;
+							await this.plugin.saveSettings();
+							await this.plugin.initialize();
+						})
+				);
+
 			new Setting(containerEl)
 				.setName("Exclude non-visible portions of links")
 				.setDesc(

--- a/logic/settings.ts
+++ b/logic/settings.ts
@@ -201,6 +201,7 @@ export interface NovelWordCountSettings {
 	includeDirectories: string;
 	excludeComments: boolean;
 	excludeCodeBlocks: boolean;
+	excludeStrikethrough: boolean;
 	excludeNonVisibleLinkPortions: boolean;
 	excludeFootnotes: boolean;
 	momentDateFormat: string;
@@ -275,6 +276,7 @@ export const DEFAULT_SETTINGS: NovelWordCountSettings = {
 	includeDirectories: "",
 	excludeComments: false,
 	excludeCodeBlocks: false,
+	excludeStrikethrough: false,
 	excludeNonVisibleLinkPortions: false,
 	excludeFootnotes: false,
 	momentDateFormat: "",


### PR DESCRIPTION
Added an option to exclude strikethroughs.
Made code blocks also count if one backtick is used
Made comments and code blocks be excludable even if the ``` or %% only appears at the start of the paragraph
